### PR TITLE
Adds put/get terminology and returns uid for put.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,27 +32,29 @@ Usage as a library
 ==================
 
 >>> queue = SafeRedisQueue(name='test')
->>> queue.push("Hello World")
->>> queue.push("Foo bar")
->>> queue.pop()
+>>> queue.put("Hello World")
+>>> queue.put("Foo bar")
+>>> queue.get()
 ('595d43b2-2e49-4e96-a1d2-0848d1c7f0d3', 'Hello World')
->>> queue.pop()
+>>> queue.get()
 ('1df060eb-b578-499d-bede-20db9da8184e', 'Foo bar')
+
+Note: to be compatible with previous versions, 2 aliases `push/pop` exist. Start using the new `put/get` terminology as soon as possible since `push/pop` will be deleted in a future version.
 
 
 ACK'ing and FAIL'ing
 --------------------
 
->>> queue.push("Good stuff")
->>> queue.push("Bad stuff")
->>> uid_good, payload_good = queue.pop()
->>> uid_bad, payload_bad = queue.pop()
+>>> queue.put("Good stuff")
+>>> queue.put("Bad stuff")
+>>> uid_good, payload_good = queue.get()
+>>> uid_bad, payload_bad = queue.get()
 ...
 # process the payloads...
 ...
 >>> queue.ack(uid_good)  # done with that one
 >>> queue.fail(uid_bad)  # something didn't work out with that one, let's requeue
->>> uid, payload = queue.pop()  # pop again; we get the requeued payload again
+>>> uid, payload = queue.get()  # get again; we get the requeued payload again
 >>> uid == uid_bad
 True
 ...
@@ -61,10 +63,10 @@ True
 >>> queue.ack(uid)  # now it worked; ACK the stuff now
 
 
-pop timeout
+get timeout
 -----------
 
-`SafeRedisQueue.pop` accepts a timeout parameter:
+`SafeRedisQueue.get` accepts a timeout parameter:
 
 - 0 (the default) blocks forever, waiting for items
 - a positive number blocks that amount of seconds

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Usage as a library
 >>> queue.get()
 ('1df060eb-b578-499d-bede-20db9da8184e', 'Foo bar')
 
-Note: to be compatible with previous versions, 2 aliases `push/pop` exist. Start using the new `put/get` terminology as soon as possible since `push/pop` will be deleted in a future version.
+Note: to be compatible with previous versions, 2 aliases ``push/pop`` exist. Start using the new ``put/get`` terminology as soon as possible since ``push/pop`` will be deleted in a future version.
 
 
 ACK'ing and FAIL'ing

--- a/saferedisqueue.py
+++ b/saferedisqueue.py
@@ -91,7 +91,7 @@ class SafeRedisQueue(object):
                 except redis.WatchError:
                     pass
 
-    def push(self, item):
+    def put(self, item):
         """Adds an item to the queue.
 
         Generates a uid for later referral.
@@ -102,8 +102,12 @@ class SafeRedisQueue(object):
                 .hset(self.ITEMS_KEY, uid, item)\
                 .lpush(self.QUEUE_KEY, uid)\
                 .execute()
+        return uid
 
-    def pop(self, timeout=0):
+    # Kept for backwards compatibility
+    push = put
+
+    def get(self, timeout=0):
         """Return next item from queue. Blocking by default.
 
         Blocks if queue is empty, see `timeout` parameter.
@@ -123,6 +127,9 @@ class SafeRedisQueue(object):
             uid = self._redis.brpoplpush(self.QUEUE_KEY, self.ACKBUF_KEY, timeout)
         item = self._redis.hget(self.ITEMS_KEY, uid)
         return uid, item
+
+    # Kept for backwards compatibility
+    pop = get
 
     def ack(self, uid):
         """Acknowledge item as successfully consumed.

--- a/saferedisqueue.py
+++ b/saferedisqueue.py
@@ -174,16 +174,16 @@ if __name__ == "__main__":
 
     if sys.argv[1] == 'producer':
         for line in sys.stdin.readlines():
-            queue.push(line.strip())
+            queue.put(line.strip())
     elif sys.argv[1] == 'consumer':
         while True:
-            uid, item = queue.pop()
+            uid, item = queue.get()
             queue.ack(uid)
             print(uid, item)
     elif sys.argv[1] == 'demo':
-        map(queue.push, ['Hello', 'World'])
+        map(queue.put, ['Hello', 'World'])
         while True:
-            uid, item = queue.pop(timeout=1)
+            uid, item = queue.get(timeout=1)
             if uid is None:
                 sys.exit()
             queue.ack(uid)

--- a/test_saferedisqueue.py
+++ b/test_saferedisqueue.py
@@ -31,13 +31,13 @@ def test_autocleanup():
     queue = SafeRedisQueue(
         name='saferedisqueue-test-%s' % uuid1().hex,
         autoclean_interval=1)
-    queue.push('bad')
-    queue.push('good')
+    queue.put('bad')
+    queue.put('good')
     assert queue._redis.llen(queue.QUEUE_KEY) == 2
     assert queue._redis.llen(queue.ACKBUF_KEY) == 0
     assert queue._redis.llen(queue.BACKUP) == 0
 
-    uid_bad, payload_bad = queue.pop()
+    uid_bad, payload_bad = queue.get()
     # Pop triggered first autoclean run before popping. At that time the
     # ackbuf was still empty, so nothing was moved to backup. But the
     # backup lock was set, to delay the next autoclean run for
@@ -46,7 +46,7 @@ def test_autocleanup():
     assert queue._redis.llen(queue.ACKBUF_KEY) == 1  # bad item
     assert queue._redis.llen(queue.BACKUP) == 0
 
-    uid_good, payload_good = queue.pop()
+    uid_good, payload_good = queue.get()
     # Autoclean started but instantly aborted due to backup lock.
     assert queue._redis.llen(queue.ACKBUF_KEY) == 2
     assert queue._redis.llen(queue.BACKUP) == 0
@@ -59,14 +59,14 @@ def test_autocleanup():
 
     # Pop after a autoclean_interval triggers cleanup internally
     time.sleep(1.2)
-    assert queue.pop(timeout=-1) == (None, None)
+    assert queue.get(timeout=-1) == (None, None)
     assert queue._redis.llen(queue.ACKBUF_KEY) == 0
     assert queue._redis.llen(queue.BACKUP) == 1
     assert queue._redis.llen(queue.QUEUE_KEY) == 0
 
     # Next pop triggers autoclean again; requeus; pops bad item again
     time.sleep(1.2)
-    assert queue.pop(timeout=-1) == (uid_bad, payload_bad)
+    assert queue.get(timeout=-1) == (uid_bad, payload_bad)
 
     # After pop, queue is empty again, item waiting in ackbuf
     assert queue._redis.llen(queue.ACKBUF_KEY) == 1
@@ -116,8 +116,8 @@ def test_decode_responses_true():
         name='saferedisqueue-test-%s' % uuid1().hex,
         decode_responses=True)
     unicode_string = unichr(3456) + u('abcd') + unichr(3421)
-    queue.push(unicode_string)
-    return_val = queue.pop()[1]
+    queue.put(unicode_string)
+    return_val = queue.get()[1]
     assert isinstance(return_val, unicode)
     assert unicode_string == return_val
 
@@ -125,7 +125,7 @@ def test_decode_responses_true():
 def test_decode_responses_false():
     queue = SafeRedisQueue(name='saferedisqueue-test-%s' % uuid1().hex)
     unicode_string = unichr(3456) + u('abcd') + unichr(3421)
-    queue.push(unicode_string)
-    return_val = queue.pop()[1]
+    queue.put(unicode_string)
+    return_val = queue.get()[1]
     assert isinstance(return_val, bytes)
     assert nativestr(unicode_string) == nativestr(return_val)


### PR DESCRIPTION
Hi Fabian,

As I explained in this ticket (https://github.com/hellp/saferedisqueue/issues/5), I think put/get is best suited for a queue than push/pop.
I also return the uid when you put an element in the queue since it can be useful for a reference.

Let me know what you think and if you are interested to integrate these changes.

Michael
